### PR TITLE
Views set up in Interface Builder should be carried over

### DIFF
--- a/UIExpandableTableView/UIExpandableTableView.m
+++ b/UIExpandableTableView/UIExpandableTableView.m
@@ -104,6 +104,14 @@ static UITableViewRowAnimation UIExpandableTableViewReloadAnimation = UITableVie
     return self;
 }
 
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    
+    self.tableHeaderView = self.tableHeaderView;
+    self.tableFooterView = self.tableFooterView;
+}
+
 #pragma mark - private methods
 
 - (void)_resetExpansionStates {


### PR DESCRIPTION
The setters aren't getting called on tableHeaderView and tableFooterView when added through IB. Adding awakeFromNib will help. There may be more that need to be added but I thought this would be a good start.
