### PR TITLE
Removed scrolling when section expands

### DIFF
--- a/SLExpandableTableView/SLExpandableTableView.m
+++ b/SLExpandableTableView/SLExpandableTableView.m
@@ -243,10 +243,6 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
 
     [self.animatingSectionsDictionary removeObjectForKey:@(section)];
 
-    [self scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]
-                atScrollPosition:UITableViewScrollPositionTop
-                        animated:animated];
-
     void(^completionBlock)(void) = ^{
         if ([self respondsToSelector:@selector(scrollViewDidScroll:)]) {
             [self scrollViewDidScroll:self];


### PR DESCRIPTION
Re issue #21.  Ive fixed it by removing the scroll animation while expanding, which still functions fine.

Note, Ive put together a demo app to illustrate the issue:
https://github.com/IdleHandsApps/ExpandableTableDemo

Cheers
Fraser
