### PR TITLE
fix example code to match interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ pod 'SLExpandableTableView'
     // call [tableView cancelDownloadInSection:section]; if your download was NOT successful
 }
 
-- (void)tableView:(SLExpandableTableView *)tableView didExpandSection:(NSUInteger)section
+- (void)tableView:(SLExpandableTableView *)tableView didExpandSection:(NSUInteger)section animated:(BOOL)animated
 {
   //...
 }
 
-- (void)tableView:(SLExpandableTableView *)tableView didCollapseSection:(NSUInteger)section
+- (void)tableView:(SLExpandableTableView *)tableView didCollapseSection:(NSUInteger)section animated:(BOOL)animated
 {
   //...
 }


### PR DESCRIPTION
as per the [header file](https://github.com/OliverLetterer/SLExpandableTableView/blob/master/SLExpandableTableView/SLExpandableTableView.h#L48):

``` objc
- (void)tableView:(SLExpandableTableView *)tableView willExpandSection:(NSUInteger)section animated:(BOOL)animated;
- (void)tableView:(SLExpandableTableView *)tableView didExpandSection:(NSUInteger)section animated:(BOOL)animated;

- (void)tableView:(SLExpandableTableView *)tableView willCollapseSection:(NSUInteger)section animated:(BOOL)animated;
- (void)tableView:(SLExpandableTableView *)tableView didCollapseSection:(NSUInteger)section animated:(BOOL)animated;
```
