### PR TITLE
add '/' to the path of 'SLExpandableTableView'

### DIFF
--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -4,7 +4,7 @@ inhibit_all_warnings!
 
 platform :ios, '6.0'
 
-pod 'SLExpandableTableView', path: '..'
+pod 'SLExpandableTableView', path: '../'
 
 target 'Tests', :exclusive => true do
   pod 'OCMock', '>= 2.2'


### PR DESCRIPTION
cause the wrong path of SLSExpandableTableView,cocoapod will return '[!] No podspec found for `SLExpandableTableView` in `..`' while installing
