### PR TITLE
Delegate method to control the animation of a cell after collapsing

### DIFF
--- a/SLExpandableTableView/SLExpandableTableView.h
+++ b/SLExpandableTableView/SLExpandableTableView.h
@@ -33,6 +33,8 @@ typedef enum {
 - (BOOL)tableView:(SLExpandableTableView *)tableView needsToDownloadDataForExpandableSection:(NSInteger)section;
 - (UITableViewCell<UIExpandingTableViewCell> *)tableView:(SLExpandableTableView *)tableView expandingCellForSection:(NSInteger)section;
 
+
+
 @end
 
 
@@ -50,6 +52,8 @@ typedef enum {
 
 - (void)tableView:(SLExpandableTableView *)tableView willCollapseSection:(NSUInteger)section animated:(BOOL)animated;
 - (void)tableView:(SLExpandableTableView *)tableView didCollapseSection:(NSUInteger)section animated:(BOOL)animated;
+
+- (BOOL)tableView:(SLExpandableTableView *)tableView shouldAnimateScrollToSection:(NSUInteger)section;
 
 @end
 

--- a/SLExpandableTableView/SLExpandableTableView.h
+++ b/SLExpandableTableView/SLExpandableTableView.h
@@ -33,8 +33,6 @@ typedef enum {
 - (BOOL)tableView:(SLExpandableTableView *)tableView needsToDownloadDataForExpandableSection:(NSInteger)section;
 - (UITableViewCell<UIExpandingTableViewCell> *)tableView:(SLExpandableTableView *)tableView expandingCellForSection:(NSInteger)section;
 
-
-
 @end
 
 

--- a/SLExpandableTableView/SLExpandableTableView.m
+++ b/SLExpandableTableView/SLExpandableTableView.m
@@ -91,7 +91,7 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
     } else if (protocol_containsSelector(@protocol(UITableViewDelegate), aSelector)) {
         return [super respondsToSelector:aSelector] || [_myDelegate respondsToSelector:aSelector];
     }
-
+    
     return [super respondsToSelector:aSelector];
 }
 
@@ -102,7 +102,7 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
     } else if (protocol_containsSelector(@protocol(UITableViewDelegate), aSelector)) {
         return _myDelegate;
     }
-
+    
     return [super forwardingTargetForSelector:aSelector];
 }
 
@@ -134,10 +134,10 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
 - (void)awakeFromNib
 {
     [super awakeFromNib];
-
+    
     _storedTableHeaderView = self.tableHeaderView;
     _storedTableFooterView = self.tableFooterView;
-
+    
     self.tableHeaderView = self.tableHeaderView;
     self.tableFooterView = self.tableFooterView;
 }
@@ -167,7 +167,7 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
     if (resetFlag) {
         [self _resetExpansionStates];
     }
-
+    
     if (self.onlyDisplayHeaderAndFooterViewIfTableViewIsNotEmpty) {
         if ([self numberOfSections] > 0) {
             if ([super tableFooterView] != self.storedTableFooterView) {
@@ -185,7 +185,7 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
             [super setTableHeaderView:self.storedTableHeaderView];
         }
     }
-
+    
     [super reloadData];
 }
 
@@ -201,60 +201,60 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
         // section is already showing, return
         return;
     }
-
+    
     [self deselectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section] animated:NO];
-
+    
     if ([self.myDataSource tableView:self needsToDownloadDataForExpandableSection:section]) {
         // data is still not ready to be displayed, return
         [self downloadDataInSection:section];
         return;
     }
-
+    
     if ([self.myDelegate respondsToSelector:@selector(tableView:willExpandSection:animated:)]) {
         [self.myDelegate tableView:self willExpandSection:section animated:animated];
     }
-
+    
     self.animatingSectionsDictionary[key] = @YES;
-
+    
     // remove the download state
     self.downloadingSectionsDictionary[key] = @NO;
-
+    
     // update the showing state
     self.showingSectionsDictionary[key] = @YES;
-
+    
     NSInteger newRowCount = [self.myDataSource tableView:self numberOfRowsInSection:section];
     // now do the animation magic to insert the new cells
     if (animated && newRowCount <= self.maximumRowCountToStillUseAnimationWhileExpanding) {
         [self beginUpdates];
-
+        
         UITableViewCell<UIExpandingTableViewCell> *cell = (UITableViewCell<UIExpandingTableViewCell> *)[self cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]];
         cell.loading = NO;
         [cell setExpansionStyle:UIExpansionStyleExpanded animated:YES];
-
+        
         NSMutableArray *insertArray = [NSMutableArray array];
         for (int i = 1; i < newRowCount; i++) {
             [insertArray addObject:[NSIndexPath indexPathForRow:i inSection:section] ];
         }
-
+        
         [self insertRowsAtIndexPaths:insertArray withRowAnimation:self.reloadAnimation];
-
+        
         [self endUpdates];
     } else {
         [self reloadDataAndResetExpansionStates:NO];
     }
-
+    
     [self.animatingSectionsDictionary removeObjectForKey:@(section)];
-
+    
     void(^completionBlock)(void) = ^{
         if ([self respondsToSelector:@selector(scrollViewDidScroll:)]) {
             [self scrollViewDidScroll:self];
         }
-
+        
         if ([self.myDelegate respondsToSelector:@selector(tableView:didExpandSection:animated:)]) {
             [self.myDelegate tableView:self didExpandSection:section animated:animated];
         }
     };
-
+    
     if (animated) {
         [CATransaction setCompletionBlock:completionBlock];
     } else {
@@ -268,58 +268,58 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
         // section is not showing, return
         return;
     }
-
+    
     if ([self.myDelegate respondsToSelector:@selector(tableView:willCollapseSection:animated:)]) {
         [self.myDelegate tableView:self willCollapseSection:section animated:animated];
     }
-
+    
     [self deselectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section] animated:NO];
-
+    
     self.animatingSectionsDictionary[key] = @YES;
-
+    
     // update the showing state
     self.showingSectionsDictionary[key] = @NO;
-
+    
     NSInteger newRowCount = [self.myDataSource tableView:self numberOfRowsInSection:section];
     // now do the animation magic to delete the new cells
     if (animated && newRowCount <= self.maximumRowCountToStillUseAnimationWhileExpanding) {
         [self beginUpdates];
-
+        
         UITableViewCell<UIExpandingTableViewCell> *cell = (UITableViewCell<UIExpandingTableViewCell> *)[self cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]];
         cell.loading = NO;
         [cell setExpansionStyle:UIExpansionStyleCollapsed animated:YES];
-
+        
         NSMutableArray *deleteArray = [NSMutableArray array];
         for (int i = 1; i < newRowCount; i++) {
             [deleteArray addObject:[NSIndexPath indexPathForRow:i inSection:section] ];
         }
-
+        
         [self deleteRowsAtIndexPaths:deleteArray withRowAnimation:self.reloadAnimation];
-
+        
         [self endUpdates];
     } else {
         [self reloadDataAndResetExpansionStates:NO];
     }
-
+    
     [self.animatingSectionsDictionary removeObjectForKey:@(section)];
-
-        if (![self.myDelegate respondsToSelector:@selector(tableView:shouldAnimateScrollToSection:)] || [self.myDelegate tableView:self shouldAnimateScrollToSection:section]) {
-            [self scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]
-                atScrollPosition:UITableViewScrollPositionTop
-                        animated:animated];
-            
-        }
-
+    
+    if (![self.myDelegate respondsToSelector:@selector(tableView:shouldAnimateScrollToSection:)] || [self.myDelegate tableView:self shouldAnimateScrollToSection:section]) {
+        [self scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]
+                    atScrollPosition:UITableViewScrollPositionTop
+                            animated:animated];
+        
+    }
+    
     void(^completionBlock)(void) = ^{
         if ([self respondsToSelector:@selector(scrollViewDidScroll:)]) {
             [self scrollViewDidScroll:self];
         }
-
+        
         if ([self.myDelegate respondsToSelector:@selector(tableView:didCollapseSection:animated:)]) {
             [self.myDelegate tableView:self didCollapseSection:section animated:animated];
         }
     };
-
+    
     if (animated) {
         [CATransaction setCompletionBlock:completionBlock];
     } else {
@@ -349,7 +349,7 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
         if (nextIndex == NSNotFound) {
             nextIndex = indexCount;
         }
-
+        
         for (NSInteger i = currentIndex + 1; i < nextIndex; i++) {
             NSUInteger newIndex = i - currentShift;
             self.expandableSectionsDictionary[@(newIndex)] = @([self.expandableSectionsDictionary[@(i)] boolValue]);
@@ -357,11 +357,11 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
             self.downloadingSectionsDictionary[@(newIndex)] = @([self.downloadingSectionsDictionary[@(i)] boolValue]);
             self.animatingSectionsDictionary[@(newIndex)] = @([self.animatingSectionsDictionary[@(i)] boolValue]);
         }
-
+        
         currentShift++;
         currentIndex = [sections indexLessThanIndex:currentIndex];
     }
-
+    
     [super deleteSections:sections withRowAnimation:animation];
 }
 
@@ -419,7 +419,7 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
             return 0;
         }
         self.expandableSectionsDictionary[key] = @YES;
-
+        
         if ([self.showingSectionsDictionary[key] boolValue]) {
             return [self.myDataSource tableView:tableView numberOfRowsInSection:section];
         } else {

--- a/SLExpandableTableView/SLExpandableTableView.m
+++ b/SLExpandableTableView/SLExpandableTableView.m
@@ -303,9 +303,12 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
 
     [self.animatingSectionsDictionary removeObjectForKey:@(section)];
 
-    [self scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]
+        if (![self.myDelegate respondsToSelector:@selector(tableView:shouldAnimateScrollToSection:)] || [self.myDelegate tableView:self shouldAnimateScrollToSection:section]) {
+            [self scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]
                 atScrollPosition:UITableViewScrollPositionTop
                         animated:animated];
+            
+        }
 
     void(^completionBlock)(void) = ^{
         if ([self respondsToSelector:@selector(scrollViewDidScroll:)]) {

--- a/SLExpandableTableView/SLExpandableTableView.m
+++ b/SLExpandableTableView/SLExpandableTableView.m
@@ -44,8 +44,10 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
 }
 
 - (void)setDelegate:(id<SLExpandableTableViewDelegate>)delegate {
-    _myDelegate = delegate;
-    [super setDelegate:self];
+    if (delegate != nil){
+        _myDelegate = delegate;
+        [super setDelegate:self];
+    }
 }
 
 - (id<UITableViewDataSource>)dataSource {


### PR DESCRIPTION
I added this method to the delegate to control the animation, since if you closed a cell which was expanded at the bottom of the screen and still went outside the screen, the tableview would scroll all the way to the top.