### PR TITLE
Added a flag to disable scrolling after section closing + weak block reference

### DIFF
--- a/SLExpandableTableView/SLExpandableTableView.h
+++ b/SLExpandableTableView/SLExpandableTableView.h
@@ -86,6 +86,11 @@ typedef enum {
 @property (nonatomic, assign) NSInteger maximumRowCountToStillUseAnimationWhileExpanding;
 
 @property (nonatomic, assign) BOOL onlyDisplayHeaderAndFooterViewIfTableViewIsNotEmpty;
+/**
+ * Defines whether the tableView should perform scroll after closing the 
+ * section. Default: YES.
+ */
+@property (nonatomic) BOOL performSectionClosingAnimation;
 
 @property (nonatomic, assign) UITableViewRowAnimation reloadAnimation;
 

--- a/SLExpandableTableView/SLExpandableTableView.m
+++ b/SLExpandableTableView/SLExpandableTableView.m
@@ -127,6 +127,7 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
     self.downloadingSectionsDictionary = [NSMutableDictionary dictionary];
     self.animatingSectionsDictionary = [NSMutableDictionary dictionary];
     self.reloadAnimation = UITableViewRowAnimationFade;
+    self.performSectionClosingAnimation = YES;
 }
 
 - (void)awakeFromNib
@@ -301,17 +302,22 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
 
     [self.animatingSectionsDictionary removeObjectForKey:@(section)];
 
-    [self scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]
-                atScrollPosition:UITableViewScrollPositionTop
-                        animated:animated];
+    if (self.performSectionClosingAnimation) {
+        [self scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]
+                    atScrollPosition:UITableViewScrollPositionTop
+                            animated:animated];
+    }
 
+    __weak typeof(self) weakSelf = self;
     void(^completionBlock)(void) = ^{
-        if ([self respondsToSelector:@selector(scrollViewDidScroll:)]) {
-            [self scrollViewDidScroll:self];
+        typeof(weakSelf) strongSelf = weakSelf;
+        
+        if (strongSelf.performSectionClosingAnimation && [strongSelf respondsToSelector:@selector(scrollViewDidScroll:)]) {
+            [strongSelf scrollViewDidScroll:strongSelf];
         }
 
-        if ([self.myDelegate respondsToSelector:@selector(tableView:didCollapseSection:animated:)]) {
-            [self.myDelegate tableView:self didCollapseSection:section animated:animated];
+        if ([strongSelf.myDelegate respondsToSelector:@selector(tableView:didCollapseSection:animated:)]) {
+            [strongSelf.myDelegate tableView:strongSelf didCollapseSection:section animated:animated];
         }
     };
 

--- a/SLExpandableTableView/SLExpandableTableView.m
+++ b/SLExpandableTableView/SLExpandableTableView.m
@@ -244,13 +244,16 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
 
     [self.animatingSectionsDictionary removeObjectForKey:@(section)];
 
+    __weak typeof(self) weakSelf = self;
     void(^completionBlock)(void) = ^{
-        if ([self respondsToSelector:@selector(scrollViewDidScroll:)]) {
-            [self scrollViewDidScroll:self];
+        typeof(weakSelf) strongSelf = weakSelf;
+
+        if ([strongSelf respondsToSelector:@selector(scrollViewDidScroll:)]) {
+            [strongSelf scrollViewDidScroll:strongSelf];
         }
 
-        if ([self.myDelegate respondsToSelector:@selector(tableView:didExpandSection:animated:)]) {
-            [self.myDelegate tableView:self didExpandSection:section animated:animated];
+        if ([strongSelf.myDelegate respondsToSelector:@selector(tableView:didExpandSection:animated:)]) {
+            [strongSelf.myDelegate tableView:strongSelf didExpandSection:section animated:animated];
         }
     };
 

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -9,5 +9,5 @@ pod 'SLExpandableTableView', path: '../'
 target 'Tests', :exclusive => true do
   pod 'OCMock', '~> 3.1.1'
   pod 'Expecta', '~> 0.3.1'
-  pod 'KIF', '~> 3.0.8'
+  pod 'KIF', '~> 3.4.1'
 end

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -1,3 +1,5 @@
+source 'https://github.com/CocoaPods/Specs.git'
+
 xcodeproj 'SLExpandableTableViewTests'
 workspace '../SLExpandableTableViewTests'
 inhibit_all_warnings!

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Expecta (0.3.1)
-  - KIF (3.0.8):
-    - KIF/XCTest (= 3.0.8)
-  - KIF/XCTest (3.0.8)
-  - OCMock (3.1.1)
+  - Expecta (0.3.2)
+  - KIF (3.4.1):
+    - KIF/Core (= 3.4.1)
+  - KIF/Core (3.4.1)
+  - OCMock (3.1.5)
   - SLExpandableTableView (1.3.1)
 
 DEPENDENCIES:
   - Expecta (~> 0.3.1)
-  - KIF (~> 3.0.8)
+  - KIF (~> 3.4.1)
   - OCMock (~> 3.1.1)
   - SLExpandableTableView (from `../`)
 
@@ -17,9 +17,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Expecta: a354d4633409dd9fe8c4f5ff5130426adbe31628
-  KIF: 3c2cb8e66fb216f9c3abcd714699411f0256f767
-  OCMock: a73f69963a8a542b0b343e2617650e4dca0cbbc2
+  Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
+  KIF: 2275c6d59c77e5e56f660f006b99d73780130540
+  OCMock: 4c2925291f80407c3738dd1db14d21d0cc278864
   SLExpandableTableView: ff63a4bb4b71c6c3ae2b7cb1cde6a36c1645f23c
 
 COCOAPODS: 0.39.0

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -4,22 +4,22 @@ PODS:
     - KIF/XCTest (= 3.0.8)
   - KIF/XCTest (3.0.8)
   - OCMock (3.1.1)
-  - SLExpandableTableView (1.2.3)
+  - SLExpandableTableView (1.3.1)
 
 DEPENDENCIES:
   - Expecta (~> 0.3.1)
   - KIF (~> 3.0.8)
   - OCMock (~> 3.1.1)
-  - SLExpandableTableView (from `..`)
+  - SLExpandableTableView (from `../`)
 
 EXTERNAL SOURCES:
   SLExpandableTableView:
-    :path: ..
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Expecta: 03aabd0a89d8dea843baecb19a7fd7466a69a31d
-  KIF: 2db5e8cf59136dd1267d49cca0d55883389b09d3
-  OCMock: f6cb8c162ab9d5620dddf411282c7b2c0ee78854
-  SLExpandableTableView: 0cd07e3cbfe9a9ad02ec9778c0778f2d5c7527f4
+  Expecta: a354d4633409dd9fe8c4f5ff5130426adbe31628
+  KIF: 3c2cb8e66fb216f9c3abcd714699411f0256f767
+  OCMock: a73f69963a8a542b0b343e2617650e4dca0cbbc2
+  SLExpandableTableView: ff63a4bb4b71c6c3ae2b7cb1cde6a36c1645f23c
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.39.0

--- a/Tests/SLExpandableTableViewTests.xcodeproj/project.pbxproj
+++ b/Tests/SLExpandableTableViewTests.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 				A79EB1FF18B49E690096FED6 /* Frameworks */,
 				A79EB20018B49E690096FED6 /* Resources */,
 				174BEE5E47F745299AFE4B18 /* Copy Pods Resources */,
+				24D7A274171885D81A6268ED /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -204,6 +205,7 @@
 				A7A7E95118B49F05000DB6D9 /* Frameworks */,
 				A7A7E95218B49F05000DB6D9 /* Resources */,
 				B0B145C3B6704B5B987307CA /* Copy Pods Resources */,
+				31E76AFE3E25D6B3CA334427 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -282,6 +284,36 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		24D7A274171885D81A6268ED /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		31E76AFE3E25D6B3CA334427 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		36A3C9BB24924104BF978D8E /* Check Pods Manifest.lock */ = {

--- a/Tests/SLExpandableTableViewTests/SLExpandableTableViewController.m
+++ b/Tests/SLExpandableTableViewTests/SLExpandableTableViewController.m
@@ -90,7 +90,7 @@
 - (id)initWithStyle:(UITableViewStyle)style
 {
     if (self = [super initWithStyle:style]) {
-        _firstSectionStrings = @[ @"Section 0 Row 0", @"Section 0 Row 1", @"Section 0 Row 2", @"Section 0 Row 3" ];
+        _firstSectionStrings = @[ @"Section 0 Row 0", @"Section 0 Row 1", @"Section 0 Row 2", @"Section 0 Row 3", @"Section 0 Row 4", @"Section 0 Row 5", @"Section 0 Row 6", @"Section 0 Row 7" ];
         _secondSectionStrings = @[ @"Section 1 Row 0", @"Section 1 Row 1", @"Section 1 Row 2", @"Section 1 Row 3", @"Section 1 Row 4" ];
 
         _sectionsArray = @[ _firstSectionStrings, _secondSectionStrings ].mutableCopy;
@@ -114,6 +114,7 @@
     SLExpandableTableView *tableView = [[SLExpandableTableView alloc] initWithFrame:[UIScreen mainScreen].bounds style:UITableViewStylePlain];
     tableView.dataSource = self;
     tableView.delegate = self;
+    tableView.performSectionClosingAnimation = NO;
     tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.view = tableView;
 }


### PR DESCRIPTION
When user closed a section, the tableView did scroll this way, that closed section was on the top of the screen. This change adds a flag, which by default behaves the same way as the old code, but if set to NO - disables this jumping.
