### PR TITLE
fix error

### DIFF
--- a/SLExpandableTableView/SLExpandableTableView.m
+++ b/SLExpandableTableView/SLExpandableTableView.m
@@ -45,7 +45,12 @@ static BOOL protocol_containsSelector(Protocol *protocol, SEL selector)
 
 - (void)setDelegate:(id<SLExpandableTableViewDelegate>)delegate {
     _myDelegate = delegate;
-    [super setDelegate:self];
+    if (delegate) {
+        //Set delegate to self only if original delegate is not nil
+        [super setDelegate:self];
+    } else{
+        [super setDelegate:nil];
+    }
 }
 
 - (id<UITableViewDataSource>)dataSource {


### PR DESCRIPTION
exception in iOS 9 while deallocating the SLExpandableTableView.
 "Cannot form weak reference to instance (xxx) of class PXUITableView_SLExpandableTableView. It is possible that this object was over-released, or is in the process of deallocation"

during the deallocation, the original code assigns self as delegate, but self is being deallocated

ref. http://stackoverflow.com/questions/32842995/login-flow-failing-after-upgrading-to-ios9
